### PR TITLE
Script to create links to eos-media

### DIFF
--- a/eos-link-user-dirs
+++ b/eos-link-user-dirs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+INSTALL_DIR=/usr/share/eos-media
+
+# Get the localized names of the user's music and pictures folders
+MUSIC_DIR=`xdg-user-dir MUSIC`
+PICTURES_DIR=`xdg-user-dir PICTURES`
+
+# Create symlinks to the default media within the user's music and pictures
+ln -nsf $INSTALL_DIR/default_files/default_music $MUSIC_DIR/eos-media
+ln -nsf $INSTALL_DIR/default_files/default_images $PICTURES_DIR/eos-media


### PR DESCRIPTION
Uses the localized folder names for Music and Pictures.
Creates symlinks in the user's music and pictures folders
to the default media folders.

[endlessm/eos-shell#827]
