### PR TITLE
Fix installation of eos-link-user-dirs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,3 +10,5 @@ uninstall-local:
 	for directory in $(media_directories); do \
 		rm -rf $(DESTDIR)$(datadir)/eos-media/$$directory; \
 	done
+
+bin_SCRIPTS = eos-link-user-dirs


### PR DESCRIPTION
The installation of this script was lost in the conversion to autotools.

[endlessm/eos-shell#978]
