### PR TITLE
Fix creation of Samples links if missing

### DIFF
--- a/eos-link-user-dirs
+++ b/eos-link-user-dirs
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 
 from gi.repository import GLib
-from subprocess import call
 import csv
 import locale
 import os
-import shutil
-import tempfile
 
 SAMPLES = { 'C':  "Samples",
             'ar': "عينات",
@@ -17,18 +14,7 @@ SAMPLES = { 'C':  "Samples",
 SAMPLES_LINK = ".samples"
 MEDIA_DIR = "/var/endless-content"
 
-LICENSE_XLS = "LICENSE.xls"
-LICENSE_CSV = "LICENSE.csv"
-
-
-def create_csv(orig, dest):
-    temp = tempfile.mkdtemp()
-    orig_file = os.path.basename(orig)
-    split_file = os.path.splitext(orig_file)
-    csv_file = os.path.join(temp, split_file[0] + '.csv')
-    call(['libreoffice', '--headless', '--convert-to', 'csv', '--outdir', temp, orig])
-    call(['iconv', '-f', 'cp1250', '-t', 'utf-8', csv_file, '-o', dest])
-    shutil.rmtree(temp)
+LICENSE_CSV = ".LICENSE.csv"
 
 
 def get_title(row, locale):
@@ -60,13 +46,10 @@ def rename_file_locale(directory, csvreader, to_locale):
 
 
 def update_files_locale(directory, to_locale):
-    temp_dir = tempfile.gettempdir()
-    license_file = os.path.join(temp_dir, LICENSE_CSV)
-    create_csv(os.path.join(directory, LICENSE_XLS), license_file)
+    license_file = os.path.join(directory, LICENSE_CSV)
     with open(license_file) as csv_file:
         csvreader = csv.DictReader(csv_file)
         rename_file_locale(directory, csvreader, to_locale)
-    os.remove(license_file)
 
 
 def get_samples(locale):


### PR DESCRIPTION
This was a regression from the conversion to python.
The renaming was working fine, but nothing was done
if the link did not exist in the first place
(as would be the case on a fresh image).

[endlessm/eos-shell#3473]
