### PR TITLE
Media: Fixed handling of operations on dev installs

### DIFF
--- a/eos-link-user-dirs
+++ b/eos-link-user-dirs
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
-from gi.repository import GLib
-import csv
 import locale
-import os
+import csv
+
+from sys import stderr
+from os import path, rename, remove, symlink
+
+from gi.repository import GLib
 
 SAMPLES = { 'C':  "Samples",
             'ar': "عينات",
@@ -16,7 +19,6 @@ MEDIA_DIR = "/var/endless-content"
 
 LICENSE_CSV = ".LICENSE.csv"
 
-
 def get_title(row, locale):
     filename_row = 'File name [' + locale + ']'
     if filename_row in row:
@@ -28,29 +30,30 @@ def get_title(row, locale):
     else:
         return get_title(row, generic_locale)
 
-
 def rename_file_locale(directory, csvreader, to_locale):
     for row in csvreader:
         for key in row.keys():
             if not key.startswith("File name"):
                 continue
-            from_filename = os.path.join(directory, row[key])
-            if os.path.exists(from_filename):
+            from_filename = path.join(directory, row[key])
+            if path.exists(from_filename):
                 break
         to_title = get_title(row, to_locale)
-        if not os.path.exists(from_filename) or not to_title:
+        if not path.exists(from_filename) or not to_title:
             continue
-        to_filename = os.path.join(directory, to_title)
+        to_filename = path.join(directory, to_title)
         if from_filename != to_filename:
-            os.rename(from_filename, to_filename)
-
+            rename(from_filename, to_filename)
 
 def update_files_locale(directory, to_locale):
-    license_file = os.path.join(directory, LICENSE_CSV)
+    license_file = path.join(directory, LICENSE_CSV)
+    if not path.exists(license_file):
+        print("Could not find video license file. Ignoring", file = stderr)
+        return
+
     with open(license_file) as csv_file:
         csvreader = csv.DictReader(csv_file)
         rename_file_locale(directory, csvreader, to_locale)
-
 
 def get_samples(locale):
     if locale in SAMPLES:
@@ -61,31 +64,32 @@ def get_samples(locale):
         return SAMPLES['C']
     else:
         return get_samples(generic_locale)
-    
 
 def update_dir_link(orig, dest, new_locale):
     # Remove the obsolete .samples link if exists
-    old_samples_file = os.path.join(dest, OLD_SAMPLES_LINK)
-    if os.path.islink(old_samples_file):
-        os.remove(old_samples_file)
+    old_samples_file = path.join(dest, OLD_SAMPLES_LINK)
+    if path.islink(old_samples_file):
+        remove(old_samples_file)
 
     new_samples = get_samples(new_locale)
     for samples in SAMPLES.values():
-        samples_dir = os.path.join(dest, samples)
+        samples_dir = path.join(dest, samples)
         if samples == new_samples:
             # Create the link using the current translation of 'Samples'
-            if not os.path.exists(samples_dir):
-                os.symlink(orig, samples_dir)
+            if not path.lexists(samples_dir):
+                if path.exists(orig):
+                    symlink(orig, samples_dir)
+                else:
+                    print("Original directory %s not found. Not Linking" % orig, file = stderr)
         else:
             # Remove any existing link with an old translation of 'Samples'
-            if os.path.islink(samples_dir):
-                os.remove(samples_dir)
-
+            if path.islink(samples_dir):
+                remove(samples_dir)
 
 new_locale = locale.getdefaultlocale()[0]
 
-update_dir_link(os.path.join(MEDIA_DIR, "music"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC), new_locale)
-update_dir_link(os.path.join(MEDIA_DIR, "pictures"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES), new_locale)
-update_dir_link(os.path.join(MEDIA_DIR, "videos"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "music"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "pictures"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "videos"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS), new_locale)
 
-update_files_locale(os.path.join(MEDIA_DIR, "videos"), new_locale);
+update_files_locale(path.join(MEDIA_DIR, "videos"), new_locale);


### PR DESCRIPTION
Since some installations do not have the media samples, we now account
for those cases and throw away the errors if encountered so that we
don't polute the system logs on shell start.

[endlessm/eos-shell#5150]