### PR TITLE
backgrounds: don't use a symlink for the default background

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ uninstall_pattern = \
 
 install-data-local:
 	@$(call install_pattern,$(images_instdir),$(images_srcdir)/*)
-	ln -fs $(images_instdir)/bg_global_02.jpg $(DESTDIR)$(pkgdatadir)/desktop-background-C.jpg
+	cp $(images_instdir)/bg_global_02.jpg $(DESTDIR)$(pkgdatadir)/desktop-background-C.jpg
 	ln -fs $(images_instdir)/bg_global_01.jpg $(DESTDIR)$(pkgdatadir)/desktop-background-es_GT.jpg
 	ln -fs $(images_instdir)/bg_brazil_01.jpg $(DESTDIR)$(pkgdatadir)/desktop-background-pt_BR.jpg
 	ln -fs $(images_instdir)/bg_china_03.jpg $(DESTDIR)$(pkgdatadir)/desktop-background-zh_CN.jpg


### PR DESCRIPTION
Instead, copy the default background. This makes it so that it can be
split in its own package.

https://phabricator.endlessm.com/T10782