### PR TITLE
Split default background into its own package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,13 @@ Homepage: http://www.endlessm.com
 
 Package: eos-media
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends},
+         eos-default-background
 Description: EndlessOS Media
  This is a package that contains the default media files (images, music, etc.)
+
+Package: eos-default-background
+Architecture: all
+Depends: ${misc:Depends}
+Description: EndlessOS default background
+ This is a package that contains the default wallpaper

--- a/debian/eos-default-background.install
+++ b/debian/eos-default-background.install
@@ -1,0 +1,1 @@
+usr/share/eos-media/desktop-background-C.jpg

--- a/debian/eos-media.install
+++ b/debian/eos-media.install
@@ -1,0 +1,4 @@
+usr/share/eos-media/default_images
+usr/share/eos-media/desktop-background-es_GT.jpg
+usr/share/eos-media/desktop-background-pt_BR.jpg
+usr/share/eos-media/desktop-background-zh_CN.jpg


### PR DESCRIPTION
So that e.g. the installer images can depend on it.

https://phabricator.endlessm.com/T10782