### PR TITLE
Add missing installation of eos-link-user-dirs

### DIFF
--- a/debian/eos-media.install
+++ b/debian/eos-media.install
@@ -1,3 +1,4 @@
+usr/bin
 usr/share/gnome-background-properties
 usr/share/eos-media/default_images
 usr/share/eos-media/desktop-background-es_GT.jpg


### PR DESCRIPTION
This was lost when the installation was refactored
into an explicit eos-media.install file.

https://phabricator.endlessm.com/T12811