### PR TITLE
eos-link-user-dirs: Fix use of deprecated enum values

### DIFF
--- a/eos-link-user-dirs
+++ b/eos-link-user-dirs
@@ -96,8 +96,8 @@ def update_dir_link(orig, dest, new_locale):
 
 new_locale = locale.getdefaultlocale()[0]
 
-update_dir_link(path.join(MEDIA_DIR, "music"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC), new_locale)
-update_dir_link(path.join(MEDIA_DIR, "pictures"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES), new_locale)
-update_dir_link(path.join(MEDIA_DIR, "videos"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "music"), GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "pictures"), GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES), new_locale)
+update_dir_link(path.join(MEDIA_DIR, "videos"), GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS), new_locale)
 
 update_files_locale(path.join(MEDIA_DIR, "videos"), new_locale);


### PR DESCRIPTION
This fixes the following warnings from eos-link-user-dirs on boot:
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]: /usr/bin/eos-link-user-dirs:99: PyGIDeprecationWarning: GLib.USER_DIRECTORY_MUSIC is deprecated; use GLib.UserDirectory.DIRECTORY_MUSIC instead
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]:   update_dir_link(path.join(MEDIA_DIR, "music"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC), new_locale)
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]: /usr/bin/eos-link-user-dirs:100: PyGIDeprecationWarning: GLib.USER_DIRECTORY_PICTURES is deprecated; use GLib.UserDirectory.DIRECTORY_PICTURES instead
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]:   update_dir_link(path.join(MEDIA_DIR, "pictures"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES), new_locale)
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]: /usr/bin/eos-link-user-dirs:101: PyGIDeprecationWarning: GLib.USER_DIRECTORY_VIDEOS is deprecated; use GLib.UserDirectory.DIRECTORY_VIDEOS instead
  Jan 27 23:44:24 endless user-dirs-update-gtk.desktop[2005]:   update_dir_link(path.join(MEDIA_DIR, "videos"), GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS), new_locale)

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23726