### PR TITLE
Remove sample media linkage script

### DIFF
--- a/debian/eos-media.install
+++ b/debian/eos-media.install
@@ -1,4 +1,3 @@
-usr/bin
 usr/share/gnome-background-properties
 usr/share/eos-media/default_images
 usr/share/eos-media/desktop-background-es_GT.jpg


### PR DESCRIPTION
With the removal of the sample media, the script to create the links is
also removed. Update the Debian packaging accordingly.