### PR TITLE
debian/control: Add meson into Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: eos-media
 Section: non-free/misc
 Priority: extra
 Maintainer: Endless OS Foundation <maintainers@endlessos.org>
-Build-Depends: debhelper-compat (= 13),
+Build-Depends: debhelper-compat (= 13), meson
 Standards-Version: 3.9.2
 Homepage: http://www.endlessos.org/
 


### PR DESCRIPTION
The eos-media configs failed at missed meson command:

[  122s]    dh_auto_configure
[  122s] 	cd obj-x86_64-linux-gnu && LC_ALL=C.UTF-8 meson setup .. --wrap-mode=nodownload --buildtype=plain --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu
[  122s] Can't exec "meson": No such file or directory at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 518.
[  122s] dh_auto_configure: error: exec (for cmd: meson setup .. --wrap-mode=nodownload --buildtype=plain --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu) failed: No such file or directory

So, add meson into eos-media's Build-Depends.